### PR TITLE
Fixed a bug where only the first _ was being replaced with a space

### DIFF
--- a/scripts/modules/typographe.js
+++ b/scripts/modules/typographe.js
@@ -28,7 +28,7 @@ function Typographe(rune)
   {
     var ctx = context;
 
-    var text = cmd.variable("text").value.replace("_"," ");
+    var text = cmd.variable("text").value.replace(/_/g," ");
     var position = cmd.position() ? cmd.position() : new Position(20,40);
     var color = cmd.color() ? cmd.color() : new Color("#000000");
     var size = cmd.value() ? cmd.value().int : 40;


### PR DESCRIPTION
Looks like `String.prototype.replace()` only replaces the first occurrence of the search arg, if the search (first) arg is a string. Using Regex with the global flag will replace all instances.