### PR TITLE
Update WORKSHOP.md to fix links

### DIFF
--- a/WORKSHOP.md
+++ b/WORKSHOP.md
@@ -127,7 +127,7 @@ In the previous example, we used the `(clear)` function, which clears the canvas
   (rect 100 100 300 300))
 ```
 
-## Pixels
+## Filters
 
 This section will cover how to manipulate the pixels of an image.
 


### PR DESCRIPTION
Third part was erroneously called 'Pixels' when it should be 'Filters', breaking the links at the top.