### PR TITLE
Fix reloading unintentionally from devtools

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -22,6 +22,8 @@ app.on('ready', () => {
     webPreferences: { zoomFactor: 1.0, nodeIntegration: true, backgroundThrottling: false }
   })
 
+  app.win.webContents.removeAllListeners('devtools-reload-page');
+
   app.win.loadURL(`file://${__dirname}/sources/index.html`)
   // app.inspect()
 


### PR DESCRIPTION
Oneliner fix for #90.

Event listener for `devtools-reload-page` is now removed on `app.on('ready')`, 
and colliding hotkey for reloading browser and running (`CmdOrCtrl+R`) will not cause problems 
 (lost progress without confirmation) anymore.
