### PR TITLE
Add ellipse shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Ronin helpers are keywords that facilitates adding coordinates from the canvas i
 - `(size w h)` Returns a size shape.
 - `(rect x y w h)` Returns a rect shape.
 - `(circle cx cy r)` Returns a circle shape.
+- `(ellipse cx cy rx ry)` Returns an ellipse shape.
 - `(line ax ay bx by)` Returns a line shape.
 - `(text x y p t ~a ~f)` Returns a text shape.
 - `(svg x y d)` Returns a svg shape.

--- a/desktop/sources/scripts/library.js
+++ b/desktop/sources/scripts/library.js
@@ -70,6 +70,10 @@ function Library (ronin) {
     return { cx, cy, r }
   }
 
+  this.ellipse = (cx, cy, rx, ry) => { // Returns a ellipse shape.
+    return { cx, cy, rx, ry }
+  }
+
   this.line = (ax, ay, bx, by) => { // Returns a line shape.
     return { a: this.pos(ax, ay), b: this.pos(bx, by) }
   }

--- a/desktop/sources/scripts/surface.js
+++ b/desktop/sources/scripts/surface.js
@@ -90,6 +90,8 @@ function Surface (ronin) {
     }
     if (isCircle(shape)) {
       this.traceCircle(shape, context)
+    } else if (isEllipse(shape)) {
+      this.traceEllipse(shape, context)
     } else if (isText(shape)) {
       this.traceText(shape, context)
     } else if (isSvg(shape)) {
@@ -120,6 +122,10 @@ function Surface (ronin) {
 
   this.traceCircle = function (circle, context) {
     context.arc(circle.cx, circle.cy, circle.r, 0, 2 * Math.PI)
+  }
+
+  this.traceEllipse = function (ellipse, context) {
+    context.ellipse(ellipse.cx, ellipse.cy, ellipse.rx, ellipse.ry, 0, 2 * Math.PI, false)
   }
 
   this.traceText = function (text, context) {
@@ -286,6 +292,9 @@ function Surface (ronin) {
   }
   function isCircle (shape) {
     return !isNaN(shape.cx) && !isNaN(shape.cy) && !isNaN(shape.r)
+  }
+  function isEllipse (shape) {
+    return !isNaN(shape.cx) && !isNaN(shape.cy) && !isNaN(shape.rx) && !isNaN(shape.ry)
   }
   function isPos (shape) {
     return !isNaN(shape.x) && !isNaN(shape.y)

--- a/examples/basics/shapes.lisp
+++ b/examples/basics/shapes.lisp
@@ -20,3 +20,7 @@
 (stroke 
   (line (sub center-w rad) center-h (add center-w rad) center-h))
 (stroke (text 10 170 200 "HELL") "pink" 2)
+
+; draw ellipse
+(stroke 
+  (ellipse center-w center-h rad (div rad 2)) "white" 2)


### PR DESCRIPTION
This PR adds a new shape for `ellipse`, fixing #76.
It uses `CanvasRenderingContext2D/ellipse` that is supported by Chromium.

Syntax: `(ellipse cx cy rx ry)`

**Screenshot**
<img width="927" alt="Screen Shot 2019-07-29 at 18 52 59" src="https://user-images.githubusercontent.com/284283/62066650-1a3fab80-b232-11e9-8d4f-a5259189fe88.png">


