### PR TITLE
About link went to Dotgrid, now Ronin

### DIFF
--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -24,7 +24,7 @@
       const ronin = new Ronin()
 
       ronin.controller = new Controller()
-      ronin.controller.add("default","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Dotgrid'); },"CmdOrCtrl+,");
+      ronin.controller.add("default","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Ronin'); },"CmdOrCtrl+,");
       ronin.controller.add("default","*","Fullscreen",() => { app.toggleFullscreen() },"CmdOrCtrl+Enter");
       ronin.controller.add("default","*","Hide",() => { app.toggleVisible() },"CmdOrCtrl+H");
       ronin.controller.add("default","*","Inspect",() => { app.inspect() },"CmdOrCtrl+.");


### PR DESCRIPTION
Clicking "About" or (command+,) linked to the Dotgrid repo. It now goes to the Ronin repo.