### PR TITLE
Allow tab injection to be affected by undo/redo

### DIFF
--- a/desktop/sources/scripts/commander.js
+++ b/desktop/sources/scripts/commander.js
@@ -125,7 +125,7 @@ function Commander (client) {
   }
 
   this.inject = function (injection, at = this._input.selectionStart) {
-    this._input.value = this._input.value.substring(0, this._input.selectionStart) + injection + this._input.value.substring(this._input.selectionEnd)
+    document.execCommand('insertText', false, injection)
     this._input.selectionEnd = at + injection.length
   }
 


### PR DESCRIPTION
I was using your textarea injection code in my own project and noticed tabs aren't affected by the undo action. Looked around and saw this is a functioning fix for chrome and electron. However, it depends on document.execCommand() which is [marked "obsolete"](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) so no hard feelings whatsoever if it's not behavior you want your code to depend on.