### PR TITLE
Add `resize` to Shapes Example

### DIFF
--- a/examples/basics/shapes.lisp
+++ b/examples/basics/shapes.lisp
@@ -6,6 +6,8 @@
 ;
 (clear)
 
+(resize 800 800)
+
 (stroke 
   (rect 0 0 300 300) colors:0)
 


### PR DESCRIPTION
The default Ronin canvas is 600x600...when the shapes example is copied directly the text shapes are truncated. Resizing ensures that the canvas is large enough to display the shape.

Fixes #133 