### PR TITLE
Fix Drawing Project Example

### DIFF
--- a/examples/projects/drawing.lisp
+++ b/examples/projects/drawing.lisp
@@ -2,7 +2,8 @@
 ;
 (clear)
 ;
-(def prev-pos {:x 0 :y 0})
+(def prev-pos:x 0)
+(def prev-pos:y 0)
 ;
 (defn stroke-color 
   (e) 


### PR DESCRIPTION
Update syntax in drawing project to fix invalid Lain definition error.

![drawing-project](https://user-images.githubusercontent.com/2012909/90896665-a8308c00-e389-11ea-91fe-984f02d36e33.png)
