### PR TITLE
Fix on-animate Example

### DIFF
--- a/examples/events/on-animate.lisp
+++ b/examples/events/on-animate.lisp
@@ -1,6 +1,7 @@
 ; this demo shows how to use the animate event to animate lines into a sine wave.
+(def frame (get-frame))
 ;
-(def seg-count 50)
+(def seg-count 100)
 ; 
 (def seg-width 
   (div frame:w seg-count)) 
@@ -22,7 +23,7 @@
       (mul 
         (sub i 1) seg-width)) 
     (def y 
-      (elevation i)) 
+      (elevation i))
     (stroke 
       (line x 
         (elevation 
@@ -36,6 +37,7 @@
 (defn redraw 
   () 
   (
-    (clear) 
-    (times seg-count draw-dash)))
+    (clear)
+    (each (range 0 seg-count) draw-dash)))
+;
 (on "animate" redraw)


### PR DESCRIPTION
Fixes #130 issue with `on-animate.lisp`

![on-animate](https://user-images.githubusercontent.com/2012909/90898052-b1baf380-e38b-11ea-8749-a924b6acdd53.png)
