### PR TITLE
Fix `map` and `filter` Functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,17 +1217,11 @@ function Library (client) {
       fn(arg, i)
     }
   }
-  this.map = (arr, fn) => { // Run a function on each element in a list.
-    return Promise.all(arr.map(fn)).then(result => { return result })
+  this.map = (arr, fn) => { // Returns a new list with fn applied to each value.
+    return arr.map(fn);
   }
-  this.filter = (arr, fn) => { // Remove from list, when function returns false.
-    const list = Array.from(arr)
-    return Promise.all(list.map((element, index) => fn(element, index, list)))
-      .then(result => {
-        return list.filter((_, index) => {
-          return result[index]
-        })
-      })
+  this.filter = (arr, fn) => { // Returns a new list, without values evaluated to false by fn.
+    return arr.filter(fn);
   }
   this.reduce = (arr, fn, acc) => {
     const length = arr.length

--- a/scripts/library.js
+++ b/scripts/library.js
@@ -424,18 +424,12 @@ function Library (client) {
     }
   }
 
-  this.map = (arr, fn) => { // Run a function on each element in a list.
-    return Promise.all(arr.map(fn)).then(result => { return result })
+  this.map = (arr, fn) => { // Returns a new list with fn applied to each value.
+    return arr.map(fn);
   }
 
-  this.filter = (arr, fn) => { // Remove from list, when function returns false.
-    const list = Array.from(arr)
-    return Promise.all(list.map((element, index) => fn(element, index, list)))
-      .then(result => {
-        return list.filter((_, index) => {
-          return result[index]
-        })
-      })
+  this.filter = (arr, fn) => { // Returns a new list, without values evaluated to false by fn.
+    return arr.filter(fn);
   }
 
   this.reduce = (arr, fn, acc) => {


### PR DESCRIPTION
Fix `map` and `filter` by removing promises.

Fix verified by running the `examples/projects/benchmark.lisp` file.

![map-filter-fix](https://user-images.githubusercontent.com/2012909/90960375-ca4c0c00-e466-11ea-9e2b-8eced80d623a.png)
